### PR TITLE
fix: widen Renovate schedule window to the first week of the month

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,8 +4,11 @@
     "config:recommended",
     "github>aquaproj/aqua-renovate-config#2.10.0"
   ],
+  // Whole first week of the month: Mend Community jobs only run every few
+  // days at arbitrary times, so a narrow window like "before 9am on the
+  // first day of the month" is almost always skipped.
   "schedule": [
-    "before 9am on the first day of the month"
+    "* * 1-7 * *"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
## Why

Same root cause as kenchan0130/terraform-provider-cloudflareext#39: `"before 9am on the first day of the month"` is a ~9 hour window once a month, but the Mend Community plan only runs jobs every ~3 days at arbitrary times, so the window is usually missed (July 1st has already been skipped — no Renovate PRs since June 21). Updates then wait a whole month for the next chance.

## What

- Widen the schedule to the whole first week of the month (`* * 1-7 * *`), keeping the monthly batching intent while making it practically impossible for the ~3-day job cadence to miss the window.

Config validated with `renovate-config-validator`: ✅

Tip: to get the pending updates immediately, press Create/Rebase on https://developer.mend.io/github/kenchan0130/intunewin after merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHAF6wRGsNYMpEh5oq35oF